### PR TITLE
Add support for fragments in the clients list

### DIFF
--- a/views/clients.haml
+++ b/views/clients.haml
@@ -4,7 +4,7 @@
     %h1 Clients
 
     - @clients_by_language.each do |language, clients|
-      %h2= language
+      %h2(id="#{language}")= language
 
       %table
         - clients.each do |client|


### PR DESCRIPTION
This allows you to link to a specific language like this:

```
http://redis.io/clients#Perl
```

I wasn't able to test it (redis-io requires Ruby 1.9, I only have 1.8.7). I'll try and install Ruby 1.9 via homebrew, but it will take awhile.

Possible improvements (I'm not a Ruby or Haml user):
- lowercase the language;
- replace . with _ (node.js for example);
- make sure it is URL-escaped  (C# for example) :).
