### PR TITLE
fix column-wrapping issue

### DIFF
--- a/views/commands.sass
+++ b/views/commands.sass
@@ -78,6 +78,11 @@
       @include column-width(100% / 2)
 
       li
+        -webkit-column-break-inside: avoid;
+        -moz-column-break-inside:    avoid;
+        -o-column-break-inside:      avoid;
+        column-break-inside:         avoid;
+
         .summary
           height: 11.5px * 3
 


### PR DESCRIPTION
There was an issue where the items on the command page would wrap to the next column. It seems to be due to the fact that each `<li>` in a column is not necessarily the same height. Their calculated height is also not an integer which is closely related to this issue.

There are a few ways to fix this, but if we're using CSS columns, the property I'm adding here seems to be the clearest solution.

See screenshot for example of wrapping issue – notice the little visible pieces of list items at the bottom of the screenshot. Those are items that ultimately wrap to the next column.

![screen shot 2013-10-12 at 3 20 14 pm](https://f.cloud.github.com/assets/197309/1320723/5f3241a6-3373-11e3-97d8-e8022a39c140.png)
