### PR TITLE
Link Pivotal logo to blog.gopivotal.com/tag/redis

### DIFF
--- a/views/layout.haml
+++ b/views/layout.haml
@@ -50,5 +50,5 @@
 
       .sponsor
         Sponsored by
-        %a(href="http://gopivotal.com")
-          %img(src="/images/pivotal.png" alt="Pivotal" width="99" height="25")
+        %a(href="http://www.gopivotal.com/products/redis")
+          %img(src="/images/pivotal.png" alt="Redis Support" title="Redis Sponsor" width="99" height="25")


### PR DESCRIPTION
http://blog.gopivotal.com/tag/redis is a more relevant endpoint
than dumping people into gopivotal.com directly.

Soon we'll have a Redis-specific page at gopivotal.com where
we can send people too.
