### PR TITLE
Remove errors from "What people are saying"

### DIFF
--- a/views/app.js
+++ b/views/app.js
@@ -99,6 +99,11 @@ function legitimate(text, user) {
     return false;
   }
 
+  /* Don't show other people's automated errors */
+  if (text.match(/Error 331, Caught exception: Redis server went away/)) {
+    return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
Somebody has a broken spam bot that includes their Redis
error message in tweets.  Not relevant.

Examples include:
Amazon bosses petitioned over 'demeaning' staff conditions Error 331, Caught exception: Redis server went away
J.Law tells embarrassing story involving sex toys and a hotel maid Error 331, Caught exception: Redis server went away
