### PR TITLE
Link Pivotal logo to Pivotal Redis page

### DIFF
--- a/views/layout.haml
+++ b/views/layout.haml
@@ -50,5 +50,5 @@
 
       .sponsor
         Sponsored by
-        %a(href="http://gopivotal.com")
-          %img(src="/images/pivotal.png" alt="Pivotal" width="99" height="25")
+        %a(href="http://www.gopivotal.com/products/redis")
+          %img(src="/images/pivotal.png" alt="Redis Support" title="Redis Sponsor" width="99" height="25")


### PR DESCRIPTION
Pivotal will add more information about Redis-specific sponsorship
and services at this new URL.
