### PR TITLE
Allow non-example code blocks to be scrolled.

### DIFF
--- a/views/styles.sass
+++ b/views/styles.sass
@@ -156,6 +156,9 @@ body
   .math
     font-weight: 700
 
+  pre
+    overflow: auto
+
   pre code, .example
     display: inline-block
     padding: 15px
@@ -185,6 +188,7 @@ body
 
     pre
       clear: both
+      overflow: visible
 
     .prompt, .command
       float: left


### PR DESCRIPTION
## Problem

Look at the pre formatted block in the Error Handling section of the [EVAL command documentation](http://redis.io/commands/eval).  It has a long line in the `pre` code block that gets clipped, without the ability to see the rest of the long line.  The clipping is happening on the `div.text` tag, which has the `overflow: hidden` property.

## Solution

Make the `pre` tag scrollable using the `overflow: auto` property.

The `div.example` block already has the `overflow: auto` property, so `pre` tags within it shouldn't be scrollable or clipped, so I avoided that with the `overflow: visible` property.