### PR TITLE
Fix overlapping header tags with text/links above

### DIFF
--- a/views/styles.sass
+++ b/views/styles.sass
@@ -11,8 +11,7 @@ body, textarea
 h1:before, h2:before, h3:before
   display: block
   content: " "
-  margin-top: -55px
-  height: 55px
+  height: 22px
   visibility: hidden
 
 h1, h2, h3


### PR DESCRIPTION
Repro steps:
1. Go to http://redis.io/documentation
2. Try to click on (any link in any last bullet point):
Redis keyspace notifications: Get notifications of keyspace events via Pub/Sub (Redis 2.8 or greater).
3. Can't click because the below header overlaps over the link