### PR TITLE
Fix overlapping header issue

### DIFF
--- a/views/styles.sass
+++ b/views/styles.sass
@@ -17,6 +17,7 @@ h1:before, h2:before, h3:before
 
 h1, h2, h3
   position: relative
+  z-index: 1
 
   a.anchor
     display: none
@@ -164,6 +165,10 @@ body
   margin: 0 auto
   max-width: $max-width - 30px * 2
   padding: 30px
+
+  aside
+    position: relative
+    z-index: 2
 
   a
     color: #0066aa


### PR DESCRIPTION
Fix overlapping header in /commands/{command} that was preventing some links in the "Related commands" aside from being clicked.

Note: this is same issue as #61 - I believe the implementation in this PR to be a better option, as I tested the propsed change in #61 and some links were still effected.