### PR TITLE
Fixes the slideout scroll problem

### DIFF
--- a/views/slideout.scss
+++ b/views/slideout.scss
@@ -1,4 +1,4 @@
-html, body {
+body {
   width: 100%;
   height: 100%;
 }


### PR DESCRIPTION
On mobile, when scrolling down the page, if you swipe over to see the menu, you get scrolled back up to the top of the page.

This fix was pulled over from Mango/slideout#21