### PR TITLE
Removes windows fork from downloads

### DIFF
--- a/downloads.json
+++ b/downloads.json
@@ -22,11 +22,6 @@
       "branch": "3.2",
       "version": "3.2.11",
       "notes": "Redis 3.2 is the previous stable release. Does not include all the improvements in Redis 4.0 but is a very battle tested release, probably a good pick for critical applications while 4.0 matures more in the next months."
-    },
-
-    "windows": {
-      "url": "https://github.com/MSOpenTech/redis",
-      "notes": "The Redis project does not officially support Windows. However, the Microsoft Open Tech group develops and maintains this Windows port targeting Win64."
     }
   }
 }


### PR DESCRIPTION
Actual repo moved to https://github.com/MicrosoftArchive/redis, project appears abandoned (https://github.com/MicrosoftArchive/redis/issues/525).

This is especially problematic vis a vis issues that have been fixed since v3 and/or are specific to the fork (ref: https://stackoverflow.com/questions/48951550/redis-scan-command-returning-keys-that-dont-match-pattern?noredirect=1#comment85027346_48951550).