### PR TITLE
Minor edits to documentation.md

### DIFF
--- a/views/documentation.md
+++ b/views/documentation.md
@@ -14,7 +14,7 @@ at once, saving on round trip time.
 * [Debugging Lua scripts](/topics/ldb): Redis 3.2 introduces a native Lua debugger for Redis scripts.
 * [Memory optimization](/topics/memory-optimization): Understand how
 Redis uses RAM and learn some tricks to use less of it.
-* [Expires](/commands/expire): Redis allows to set a time to live different for every key so that the key will be automatically removed from the server when it expires.
+* [Expires](/commands/expire): Redis allows setting a different time to live for every key so that the key will be automatically removed from the server when it expires.
 * [Redis as an LRU cache](/topics/lru-cache): How to configure and use Redis as a cache with a fixed amount of memory and auto eviction of keys.
 * [Redis transactions](/topics/transactions): It is possible to group commands together so that they are executed as a single transaction.
 * [Mass insertion of data](/topics/mass-insert): How to add a big amount of pre existing or generated data to a Redis instance in a short time.
@@ -27,7 +27,7 @@ Redis modules API
 ---
 
 * [Introduction to Redis modules](/topics/modules-intro). A good place to start learing about Redis 4.0 modules programming.
-* [Implementing native data types](/topics/modules-native-types). Modules scan implement new data types (data structures and more) that look like built-in data types. This documentation covers the API to do so.
+* [Implementing native data types](/topics/modules-native-types). Modules can implement new data types (data structures and more) that look like built-in data types. This documentation covers the API to do so.
 * [Blocking operations](topics/modules-blocking-ops)  with modules. This is still an experimental API, but a very powerful one to write commands that can block the client (without blocking Redis) and can execute tasks in other threads.
 * [Redis modules API reference](topics/modules-api-ref). Directly generated from the top comments in the source code inside `src/module.c`. Contains many low level details about API usage.
 


### PR DESCRIPTION
 * `scan` typo... `can`

 * read through the page and thought the TTL line read better that way

Thanks for great docs.