### PR TITLE
Update the download link from 5.0.5 to 5.0.6

### DIFF
--- a/downloads.json
+++ b/downloads.json
@@ -7,7 +7,7 @@
 
      "stable": {
        "branch": "5.0",
-       "version": "5.0.5",
+       "version": "5.0.6",
        "notes": "Redis 5.0 is the first version of Redis to introduce the new stream data type with consumer groups, sorted sets blocking pop operations, LFU/LRU info in RDB, Cluster manager inside redis-cli, active defragmentation V2, HyperLogLogs improvements and many other improvements. Redis 5 was release as GA in October 2018."
      },
 


### PR DESCRIPTION
5.0.6 is the latest version, but the download link still leads to 5.0.5.