### PR TITLE
Removed the Try it Link because the link is broken

### DIFF
--- a/views/home.haml
+++ b/views/home.haml
@@ -8,15 +8,6 @@
   .home-intro.home-section
 
     %section
-      %h2 Try it
-
-      %p
-        Ready for a test drive? Check this
-        %a(href="http://try.redis.io") interactive tutorial
-        that will walk you through the most important features of
-        Redis.
-
-    %section
       %h2 Download it
 
       %p


### PR DESCRIPTION
The interactive tutorial link to a page with
 " Unmaintained
try.redis.io is unmaintained and had to be shut off due to security issues.
Go to redis.io directly and browse the documentation." 

Hence the removal